### PR TITLE
Minor changes (typos, keep up with rust stable) 

### DIFF
--- a/src/lib/gf256.rs
+++ b/src/lib/gf256.rs
@@ -1,5 +1,5 @@
 //! This module provides the Gf256 type which is used to represent
-//! elements of a finite field wich 256 elements.
+//! elements of a finite field with 256 elements.
 
 use std::ops::{ Add, Sub, Mul, Div };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 
 	if args.len() < 2 || opt_matches.opt_present("h") {
 		println!(
-"The program secretshare is an implementation of Shamir's secret sharing scheme.\n\
+"The program rustysecrets is an implementation of Shamir's secret sharing scheme.\n\
  It is applied byte-wise within a finite field for arbitrarily long secrets.\n");
 		println!("{}", opts.usage("Usage: rustysecrets [options]"));
 		println!("Input is read from STDIN and output is written to STDOUT.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod lib;
 
 use std::io;
 use std::env;
+use std::process;
 
 enum Action {
 	Encode(u8, u8), // k and n parameter
@@ -39,8 +40,7 @@ fn main() {
 		Ok(m) => m,
 		Err(f) => {
 			drop(writeln!(&mut stderr, "Error: {}", f));
-			// env::set_exit_status(1); // FIXME: unstable feature
-			return;
+			process::exit(1);
 		}
 	};
 
@@ -84,7 +84,7 @@ fn main() {
 
 	if let Err(e) = result {
 		drop(writeln!(&mut stderr, "{}", e));
-		// env::set_exit_status(1); // FIXME: unstable feature
+		process::exit(1);
 	}
 }
 


### PR DESCRIPTION
Nothing big here: Just changes I did locally while skimming through the code: [std::process::exit](https://doc.rust-lang.org/std/process/fn.exit.html) is stable now and one or two typos. Feel free to ignore if not useful.
Looks like a nice job btw :+1:.